### PR TITLE
Fix docs URL in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Copyright Georgia Tech 2024
 
 [![test status](https://github.com/AI4OPT/ML4OPF/workflows/tests/badge.svg)](https://github.com/AI4OPT/ML4OPF/actions/workflows/tests.yaml)
 [![coverage](.github/coverage.svg)](https://github.com/AI4OPT/ML4OPF/actions/workflows/tests.yaml)
-[![docs status](https://github.com/AI4OPT/ML4OPF/workflows/docs/badge.svg)](https://pages.github.com/AI4OPT/ML4OPF/index.html)
+[![docs status](https://github.com/AI4OPT/ML4OPF/workflows/docs/badge.svg)](https://ai4opt.github.io/ML4OPF/)
 
 # ML4OPF
 


### PR DESCRIPTION
The current docs badge in the README sends to a 404 page.
I updated the target URL so that it redirects here: https://ai4opt.github.io/ML4OPF/