### PR TITLE
Fix `BasicNeuralNet.load_from_checkpoint`

### DIFF
--- a/ml4opf/models/__init__.py
+++ b/ml4opf/models/__init__.py
@@ -8,7 +8,7 @@ directly as needed. For instance, to load the BasicNeuralNet for ACOPF,
 you would use:
 
 ```python
-from ml4opf.models.acp.basic_nn import BasicNeuralNet
+from ml4opf.models.basic_nn import ACPBasicNeuralNet
 ```
 
 """

--- a/ml4opf/models/basic_nn/basic_nn.py
+++ b/ml4opf/models/basic_nn/basic_nn.py
@@ -133,14 +133,11 @@ class BasicNeuralNet(OPFModel, ABC):
         if not path.is_dir(): # pragma: no cover
             raise ValueError(f"Checkpoint path must be a directory. Got: {path}")
 
-        self.trainer.save_checkpoint(path / "trainer.ckpt")
-
-        with open(path / "config.json", "w") as f:
-            self.init_config["__cls"] = self.__class__.__name__
-            self.init_config["__model_cls"] = self.model.__class__.__name__
-            json.dump(self.init_config, f)
-            del self.init_config["__cls"]
-            del self.init_config["__model_cls"]
+        checkpoint = self.trainer._checkpoint_connector.dump_checkpoint(False)
+        checkpoint["__cls"] = self.__class__.__name__
+        checkpoint["__model_cls"] = self.model.__class__.__name__
+        self.trainer.strategy.save_checkpoint(checkpoint, path / "trainer.ckpt", storage_options=None)
+        self.trainer.strategy.barrier("Trainer.save_checkpoint")
 
     @classmethod
     def load_from_checkpoint(cls, path_to_folder: str, problem: OPFProblem):
@@ -161,26 +158,23 @@ class BasicNeuralNet(OPFModel, ABC):
             # else:
             raise ValueError(f"Checkpoint path must be a directory! Got: {path}")
 
-        assert (path / "config.json").exists(), f"Checkpoint config file not found at {path}/config.json"
         assert (path / "trainer.ckpt").exists(), f"Checkpoint model file not found at {path}/trainer.ckpt"
 
-        with open(path / "config.json", "r") as f:
-            config = json.load(f)
+        with open(path / "trainer.ckpt", "rb") as f:
+            d = torch.load(f, weights_only=False)
+            config = d['hyper_parameters']
+            assert d["__cls"] == cls.__name__, f"Checkpoint class {d['__cls']} does not match {cls.__name__}"
+            config__model_cls = d["__model_cls"]
+            del d["__cls"]
+            del d["__model_cls"]
 
-        with open(path.parent / "hparams.yaml", "r") as f:
-            hparams = yaml.load(f, Loader=yaml.Loader)
+            slices = config.pop("slices")
+            me = cls(config=config, problem=problem)
+            me.slices = slices
 
-        assert config["__cls"] == cls.__name__, f"Checkpoint class {config['__cls']} does not match {cls.__name__}"
-        config__model_cls = config["__model_cls"]
-        del config["__cls"]
-        del config["__model_cls"]
-
-        me = cls(config=config, problem=problem)
-        me.slices = hparams["slices"]
-
-        assert (
-            config__model_cls == me.model_cls.__name__
-        ), f"Checkpoint model class {config__model_cls} does not match {me.model_cls.__name__}"
+            assert (
+                config__model_cls == me.model_cls.__name__
+            ), f"Checkpoint model class {config__model_cls} does not match {me.model_cls.__name__}"
 
         me.model = me.model_cls.load_from_checkpoint(path / "trainer.ckpt", opfmodel=me)
         return me

--- a/ml4opf/models/basic_nn/basic_nn.py
+++ b/ml4opf/models/basic_nn/basic_nn.py
@@ -175,7 +175,7 @@ class BasicNeuralNet(OPFModel, ABC):
         del config["__cls"]
         del config["__model_cls"]
 
-        me = cls(config, problem)
+        me = cls(config=config, problem=problem)
         me.slices = hparams["slices"]
 
         assert (

--- a/ml4opf/models/ldf_nn/__init__.py
+++ b/ml4opf/models/ldf_nn/__init__.py
@@ -1,4 +1,4 @@
-""" A basic feed-forward fully-connected neural network for ACOPF, using the `LDFLoss` loss function."""
+""" A basic feed-forward fully-connected neural network, using the `LDFLoss` loss function."""
 
 try:
     from ml4opf.models.ldf_nn.acp_ldf_nn import ACPLDFNeuralNet

--- a/ml4opf/models/ldf_nn/ldf_nn.py
+++ b/ml4opf/models/ldf_nn/ldf_nn.py
@@ -26,8 +26,9 @@ class LDFNN(BasicNN):
         update_freq: int = 500,
         divide_by_counter: bool = True,
         exclude_keys: list[str] = [],
+        weight_init_seed: int = 42,
     ):
-        super().__init__(opfmodel, slices, optimizer, loss, hidden_sizes, activation, boundrepair, learning_rate)
+        super().__init__(opfmodel, slices, optimizer, loss, hidden_sizes, activation, boundrepair, learning_rate, weight_init_seed)
 
         self.loss = LDFLoss(
             self.violation,

--- a/ml4opf/models/ldf_nn/ldf_nn.py
+++ b/ml4opf/models/ldf_nn/ldf_nn.py
@@ -57,6 +57,3 @@ class LDFNN(BasicNN):
 
 class LDFNeuralNet(BasicNeuralNet):
     model: LDFNN
-
-    def __init__(self, config, ldf_config, problem):
-        super().__init__(dict(**config, **ldf_config), problem)

--- a/ml4opf/models/penalty_nn/__init__.py
+++ b/ml4opf/models/penalty_nn/__init__.py
@@ -1,4 +1,4 @@
-""" A basic feed-forward fully-connected neural network for ACOPF, using the `PenaltyLoss` loss function."""
+""" A basic feed-forward fully-connected neural network, using the `PenaltyLoss` loss function."""
 
 try:
     from ml4opf.models.penalty_nn.acp_penalty_nn import ACPPenaltyNeuralNet

--- a/ml4opf/models/penalty_nn/penalty_nn.py
+++ b/ml4opf/models/penalty_nn/penalty_nn.py
@@ -26,8 +26,9 @@ class PenaltyNN(BasicNN):
         learning_rate: float = 1e-3,
         exclude_keys: Optional[Union[str, list[str]]] = None,
         multipliers: Optional[Union[float, dict[str, float]]] = None,
+        weight_init_seed: int = 42,
     ):
-        super().__init__(opfmodel, slices, optimizer, loss, hidden_sizes, activation, boundrepair, learning_rate)
+        super().__init__(opfmodel, slices, optimizer, loss, hidden_sizes, activation, boundrepair, learning_rate, weight_init_seed)
 
         self.loss = PenaltyLoss(self.violation, exclude_keys, multipliers)
 

--- a/ml4opf/models/penalty_nn/penalty_nn.py
+++ b/ml4opf/models/penalty_nn/penalty_nn.py
@@ -44,6 +44,3 @@ class PenaltyNN(BasicNN):
 
 class PenaltyNeuralNet(BasicNeuralNet):
     model: PenaltyNN
-
-    def __init__(self, config, penalty_config, problem):
-        super().__init__(dict(**config, **penalty_config), problem)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,10 @@ def test_models():
     from ml4opf.models.ldf_nn.ed_ldf_nn import EDLDFNeuralNet
     from ml4opf.models.e2elr.e2elr import EDE2ELRNeuralNet
 
-    def make_model(problem: OPFProblem, *args, kind="basic", **kwargs):
+    def make_model(problem: OPFProblem, config: dict, kind="basic", loss_config: Optional[dict] = None):
+        if loss_config is None:
+            loss_config = dict()
+
         if kind == "basic":
             if isinstance(problem, ACPProblem):
                 cls = ACPBasicNeuralNet
@@ -55,7 +58,7 @@ def test_models():
         else:
             raise ValueError(f"Unknown model kind: {kind}. Must be one of 'basic', 'ldf', or 'penalty'.")
         
-        return cls(*args, problem=problem, **kwargs)
+        return cls(config=dict(**config, **loss_config), problem=problem)
 
     from ml4opf.models.basic_nn.basic_nn import BasicNeuralNet # all the models are subclasses of this
     from pathlib import Path
@@ -160,18 +163,18 @@ def test_models():
         "exclude_keys": [],
     }
 
-    acp_ldf_nn = make_model(acp_problem, config, kind="ldf", ldf_config=ldf_config)
-    dcp_ldf_nn = make_model(dcp_problem, config, kind="ldf", ldf_config=ldf_config)
-    ed_ldf_nn = make_model(ed_problem, config, kind="ldf", ldf_config=ldf_config)
+    acp_ldf_nn = make_model(acp_problem, config, kind="ldf", loss_config=ldf_config)
+    dcp_ldf_nn = make_model(dcp_problem, config, kind="ldf", loss_config=ldf_config)
+    ed_ldf_nn = make_model(ed_problem, config, kind="ldf", loss_config=ldf_config)
 
     penalty_config = {
         "exclude_keys": [],
         "multipliers": 1e-2,
     }
 
-    acp_penalty_nn = make_model(acp_problem, config, kind="penalty", penalty_config=penalty_config)
-    dcp_penalty_nn = make_model(dcp_problem, config, kind="penalty", penalty_config=penalty_config)
-    ed_penalty_nn = make_model(ed_problem, config, kind="penalty", penalty_config=penalty_config)
+    acp_penalty_nn = make_model(acp_problem, config, kind="penalty", loss_config=penalty_config)
+    dcp_penalty_nn = make_model(dcp_problem, config, kind="penalty", loss_config=penalty_config)
+    ed_penalty_nn = make_model(ed_problem, config, kind="penalty", loss_config=penalty_config)
 
 
     models = [acp_basic_nn, dcp_basic_nn, ed_basic_nn, e2elr_nn, acp_ldf_nn, dcp_ldf_nn, ed_ldf_nn, acp_penalty_nn, dcp_penalty_nn, ed_penalty_nn]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-
+from typing import Optional
 
 def test_models():
 
@@ -197,13 +197,19 @@ def test_models():
     ed_predict(ed_ldf_nn)
 
     load_checkpoint(acp_basic_nn)
+    load_checkpoint(dcp_ldf_nn)
+    load_checkpoint(ed_penalty_nn)
+
+    acp_predict(acp_penalty_nn)
+    dcp_predict(dcp_penalty_nn)
+    ed_predict(ed_penalty_nn)
 
     config["optimizer"] = "adamw"
-    make_model(ed_problem, config, kind="basic")
+    make_model(acp_problem, config, kind="basic")
 
     config["optimizer"] = "sgd"
-    make_model(ed_problem, config, kind="basic")
+    make_model(dcp_problem, config, kind="ldf", loss_config=ldf_config)
 
     config["optimizer"] = "nonexistent"
-    make_model(ed_problem, config, kind="basic")
+    make_model(ed_problem, config, kind="penalty", loss_config=penalty_config)
 


### PR DESCRIPTION
Closes #7 and fixes a bug with LDF/Penalty checkpoints. We now save the checkpoint all in one `trainer.ckpt` file, without relying on `config.json` or `hparams.yaml`