### PR TITLE
Set minimum `pytorch-cuda` version

### DIFF
--- a/environment_cuda.yml
+++ b/environment_cuda.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - python=3
   - pytorch::pytorch
-  - pytorch::pytorch-cuda
+  - pytorch::pytorch-cuda>12


### PR DESCRIPTION
Closes #9 by setting `pytorch::pytorch-cuda>12`