### PR TITLE
Only run CI on PRs into `main`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
   pull_request:
-
+    branches:
+      - main
 jobs:
   run_docs:
     name: Run tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Copyright Georgia Tech 2024
 
-[![test status](https://github.com/AI4OPT/ML4OPF/workflows/tests/badge.svg)](https://github.com/AI4OPT/ML4OPF/actions/workflows/tests.yaml)<!-- [![coverage](.github/coverage.svg)](https://github.com/AI4OPT/ML4OPF/actions/workflows/tests.yaml) -->
+[![test status](https://github.com/AI4OPT/ML4OPF/workflows/tests/badge.svg?branch=main)](https://github.com/AI4OPT/ML4OPF/actions/workflows/tests.yaml)<!-- [![coverage](.github/coverage.svg)](https://github.com/AI4OPT/ML4OPF/actions/workflows/tests.yaml) -->
 [![docs status](https://github.com/AI4OPT/ML4OPF/workflows/docs/badge.svg)](https://ai4opt.github.io/ML4OPF/)
 
 # ML4OPF


### PR DESCRIPTION
This should also prevent PRs with failing CI from messing up the README badge on `main`.