### PR TITLE
Only temporarily `gunzip` H5 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,6 @@ logs
 
 wandb/
 .vscode/
-test
+/test
 .DS_Store
 notes.ipynb

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -41,6 +41,8 @@ def test_basic_usage():
         "basic_300bus"
     )  # creates a folder called "basic_300bus" with two files in it, trainer.ckpt and config.json
 
+    # delete it
+    import shutil; shutil.rmtree("basic_300bus")
 
 def test_advanced_usage():
     import logging


### PR DESCRIPTION
The files are now unzipped into a tempfile every time they are read, with a warning telling users to store uncompressed versions if it takes too long.

This is mainly motivated by #38 

cc @mtanneau 